### PR TITLE
Compile fix for external projects + vibe.d convenience functions.

### DIFF
--- a/source/embd.d
+++ b/source/embd.d
@@ -112,6 +112,14 @@ version (Have_vibe_d)
         Note that these functions are only available if "vibe-d" is available
         as a dependency or if a "Have_vibe_d" version identifier is specified
         manually.
+
+        Examples:
+
+            ---
+            string caption = "Hello, World!";
+            //res.renderEmbd!("test.embd", caption)();
+            res.bodyWriter.renderEmbdCompat!("test.embd", string, "caption")(caption);
+            ---
     */
     void renderEmbd(string FILE, ALIASES...)(OutputStream dst)
     {


### PR DESCRIPTION
Hi! I finally got around to try out embd and made some working `render!()`-like functions for use in a vibe.d context. Everything worked like a charm once it compiled. I just needed to move the `createRenderingCode` into `Context` so that it is accessible from within the mixin in external modules. The vibe.d specific functions will only be compiled if "vibe-d" was explicitly added to a project as a dependency.
