### PR TITLE
 embd.d - fix incompatibility to current vibe.d releases

### DIFF
--- a/source/embd.d
+++ b/source/embd.d
@@ -72,9 +72,11 @@ interface Context {
 
 version (Have_vibe_d)
 {
-    import vibe.core.stream;
-    import vibe.templ.utils;
-    import vibe.textfilter.html;
+    import vibe.core.stream : OutputStream;
+   	import vibe.stream.wrapper : streamOutputRange;
+   	import vibe.http.server : HTTPServerResponse;
+	import diet.input;
+    import vibe.textfilter.html : filterHTMLEscape;
 
     /** Renders an EMBD template to an output stream.
 
@@ -93,10 +95,10 @@ version (Have_vibe_d)
             res.bodyWriter.renderEmbdCompat!("test.embd", string, "caption")(caption);
             ---
     */
+    @safe
     void renderEmbd(string FILE, ALIASES...)(OutputStream dst)
     {
-
-        mixin(vibe.templ.utils.localAliases!(0, ALIASES));
+    mixin( diet.input.localAliasesMixin!( 0, ALIASES));
 
         class LocalContext : Context {
             OutputStream output__;
@@ -105,9 +107,10 @@ version (Have_vibe_d)
 
             void write(string content, dchar eval_code)
             {
-                if (eval_code == '=')
-                    filterHtmlEscape(output__, content);
-                else
+                if (eval_code == '=') {
+					auto buf = streamOutputRange!1024( output__);
+					filterHTMLEscape( buf, content);
+                } else
                     output__.write(content, false);
             }
         }
@@ -118,6 +121,7 @@ version (Have_vibe_d)
     }
 
     /// ditto
+    @safe
     void renderEmbd(string FILE, ALIASES...)(HTTPServerResponse res, string content_type = "text/html; charset=UTF-8")
     {
         res.contentType = content_type;
@@ -125,6 +129,7 @@ version (Have_vibe_d)
     }
 
     /// ditto
+    @safe
     void renderEmbdCompat(string FILE, TYPES_AND_NAMES...)(OutputStream dst, ...)
     {
         import core.vararg;
@@ -138,9 +143,10 @@ version (Have_vibe_d)
 
             void write(string content, dchar eval_code)
             {
-                if (eval_code == '=')
-                    filterHtmlEscape(output__, content);
-                else
+                if (eval_code == '=') {
+					auto buf = streamOutputRange!1024( output__);
+					filterHTMLEscape( buf, content);
+                } else
                     output__.write(content, false);
             }
         }

--- a/source/embd.d
+++ b/source/embd.d
@@ -73,8 +73,8 @@ interface Context {
 version (Have_vibe_d)
 {
     import vibe.core.stream : OutputStream;
-   	import vibe.stream.wrapper : streamOutputRange;
-   	import vibe.http.server : HTTPServerResponse;
+    import vibe.stream.wrapper : streamOutputRange;
+    import vibe.http.server : HTTPServerResponse;
 	import diet.input;
     import vibe.textfilter.html : filterHTMLEscape;
 
@@ -108,8 +108,8 @@ version (Have_vibe_d)
             void write(string content, dchar eval_code)
             {
                 if (eval_code == '=') {
-					auto buf = streamOutputRange!1024( output__);
-					filterHTMLEscape( buf, content);
+                    auto buf = streamOutputRange!1024( output__);
+                    filterHTMLEscape( buf, content);
                 } else
                     output__.write(content, false);
             }
@@ -144,8 +144,8 @@ version (Have_vibe_d)
             void write(string content, dchar eval_code)
             {
                 if (eval_code == '=') {
-					auto buf = streamOutputRange!1024( output__);
-					filterHTMLEscape( buf, content);
+                    auto buf = streamOutputRange!1024( output__);
+                    filterHTMLEscape( buf, content);
                 } else
                     output__.write(content, false);
             }


### PR DESCRIPTION
filterHtmlEscape( ...) is deprecated since vibe.d version 0.7.17 and was removed with version 0.7.20 .
since vibe.d 0.7.17 the function filterHTMLEscape( ...) is to use - instead of filterHtmlEscape( ...).